### PR TITLE
Use prebuilt Circle CI node image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 jobs:
-  validate:
-    machine: true
+  build:
+    docker:
+      - image: circleci/node:10.10.0
     steps:
       - checkout
       - restore_cache:
@@ -16,23 +17,6 @@ jobs:
       - run:
           name: Lint
           command: npm run lint
-  build:
-    machine: true
-    steps:
-      - checkout
-      - restore_cache:
-          key: node_modules-cache-{{ checksum "package.json" }}
       - run:
-          name: Install NPM packages
-          command: npm install
-      - save_cache:
-          key: node_modules-cache-{{ checksum "package.json" }}
-          paths:
-            - node_modules
-      - run: npm run build
-workflows:
-  version: 2
-  build_and_test:
-    jobs:
-      - validate
-      - build
+          name: Build
+          command: npm run build


### PR DESCRIPTION
Use the docker executor in Circle CI instead with a prebuild node image. The machine executor allocates a full VM and also using older versions of node.